### PR TITLE
Fix .zshrc syntax

### DIFF
--- a/templates/users/php.dev.j2
+++ b/templates/users/php.dev.j2
@@ -57,7 +57,7 @@
 
 # User configuration
 
-{{ macros.config_row(config, 'export PATH', 'export PATH=""./bin:./vendor/bin:$PATH"') }}
+{{ macros.config_row(config, 'export PATH', 'export PATH="./bin:./vendor/bin:$PATH"') }}
 {{ macros.config_row(config, 'export MANPATH', '# export MANPATH="/usr/local/man:$MANPATH"', true) }}
 
 source $ZSH/oh-my-zsh.sh


### PR DESCRIPTION
Fix broken prompt : 

```
Last login: Wed Jun 22 08:08:57 2016 from 10.0.2.2
/home/app/.zshrc:56: bad pattern: e[36m‣e[0m
vm-manala% 
vm-manala% exit
```