### PR TITLE
[xdebug] Add status

### DIFF
--- a/templates/users/_function_php_xdebug.j2
+++ b/templates/users/_function_php_xdebug.j2
@@ -7,7 +7,7 @@ manala_php_xdebug () {
 			sudo phpenmod -v 7.0 -s ALL xdebug;
 			sudo service php7.0-fpm restart;
 		fi
-	else
+	elif [[ $1 == off ]]; then
 		if hash php5dismod 2>/dev/null; then
 			sudo php5enmod xdebug;
 			sudo service php5-fpm restart;
@@ -15,9 +15,15 @@ manala_php_xdebug () {
 			sudo phpdismod -v 7.0 -s ALL xdebug;
 			sudo service php7.0-fpm restart;
 		fi
-	fi
+    else
+        if [[ $(/usr/bin/php -v 2>/dev/null) != *Xdebug* ]]; then
+            echo disabled
+        else
+            echo enabled
+        fi
+    fi
 }
 
 echo -e " \e[36m‣\e[0m \e[36mENABLE/DISABLE PHP XDEBUG\e[0m
-	manala_php_xdebug on|off
+	manala_php_xdebug status|on|off
 "


### PR DESCRIPTION
```sh
$ manala_php_xdebug status
# enabled

$ manala_php_xdebug off
$ manala_php_xdebug status
# disabled
```

If no arg is specified (or an unknown arg), the status is displayed instead of unexpectedly disabling xdebug